### PR TITLE
Fix Enabled property not working properly

### DIFF
--- a/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
+++ b/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
@@ -912,7 +912,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
 
                 customize.SetControlState(control.Id, state);
             }
-            else if (propertyName == "Enabled" && dialogControl != null)
+            else if (propertyName == "Enabled" && (dialogControl = control as CommonFileDialogControl) != null)
             {
                 ShellNativeMethods.ControlState state;
                 customize.GetControlState(control.Id, out state);


### PR DESCRIPTION
The enabled property does not work currently when using the CustomFileDialog controls because the dialogControl variable is never initialized and will always be null when attempting to set the "Enabled" flag.

I've modified the "Enabled" if condition to mimic what the "Visible" if condition was already doing.