### PR TITLE
Fix the implementation of the property CheckSelect

### DIFF
--- a/source/WindowsAPICodePack/Shell/ExplorerBrowser/ExplorerBrowserEnums.cs
+++ b/source/WindowsAPICodePack/Shell/ExplorerBrowser/ExplorerBrowserEnums.cs
@@ -98,7 +98,7 @@ namespace Microsoft.WindowsAPICodePack.Controls
         /// <summary>
         /// Turns on check mode for the view
         /// </summary>
-        CheckSelect = 0x08040000,
+        CheckSelect = 0x08000000,
         /// <summary>
         /// When the view is set to "Tile" the layout of a single item should be extended to the width of the view.
         /// </summary>


### PR DESCRIPTION
The previous value, a combination of FWF_CHECKSELECT and FWF_AUTOCHECKSELECT
prevented navigation on double click, making this property worthless.

The new value used corresponds to FWF_AUTOCHECKSELECT,
and is the same mode used by the Windows explorer when checkboxes are enabled.