### PR TITLE
Fix Command link description display bug.

### DIFF
--- a/source/WindowsAPICodePack/Core/Dialogs/TaskDialogs/TaskDialogCommandLink.cs
+++ b/source/WindowsAPICodePack/Core/Dialogs/TaskDialogs/TaskDialogCommandLink.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 namespace Microsoft.WindowsAPICodePack.Dialogs
 {
     /// <summary>
-    /// Represents a command-link. 
+    /// Represents a command-link.
     /// </summary>
     public class TaskDialogCommandLink : TaskDialogButton
     {
@@ -52,7 +52,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
         {
             return string.Format(CultureInfo.CurrentCulture, "{0}{1}{2}",
                 Text ?? string.Empty,
-                (!string.IsNullOrEmpty(Text) && !string.IsNullOrEmpty(instruction)) ? Environment.NewLine : string.Empty,
+                (!string.IsNullOrEmpty(Text) && !string.IsNullOrEmpty(instruction)) ? "\n" : string.Empty,
                 instruction ?? string.Empty);
         }
     }


### PR DESCRIPTION
Using Environment.NewLine in GUI environments wil generate a bad displayed command link. Since the Windows internally recognize both \r and \n as line breakes in SetText Win32 functions, and the Enviroment.NewLine will usually be \r\n in GUI based projects. Thus an additional white line will appear in the command link. Change Environment.NewLine into simple \n can solve this problem.