### PR TITLE
Feature proposal: custom SelectionChangedEventArgs for selected folder and file names

### DIFF
--- a/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
+++ b/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialog.cs
@@ -121,7 +121,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
         public event EventHandler<CommonFileDialogFolderChangeEventArgs> FolderChanging;
 
         /// <summary>Raised when the user changes the selection in the dialog's view.</summary>
-        public event EventHandler SelectionChanged;
+        public event EventHandler<CommonFileDialogSelectionChangedEventArgs> SelectionChanged;
 
         /// <summary>Indicates whether this feature is supported on the current platform.</summary>
         public static bool IsPlatformSupported =>
@@ -280,7 +280,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
 
                 var returnFilename = filenames[0];
 
-                if(this is CommonSaveFileDialog)
+                if (this is CommonSaveFileDialog)
                 {
                     returnFilename = System.IO.Path.ChangeExtension(returnFilename, this.filters[this.SelectedFileTypeIndex - 1].Extensions[0]);
                 }
@@ -827,7 +827,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
         /// Raises the <see cref="CommonFileDialog.SelectionChanged"/> event when the user changes the selection in the dialog's view.
         /// </summary>
         /// <param name="e">The event data.</param>
-        protected virtual void OnSelectionChanged(EventArgs e)
+        protected virtual void OnSelectionChanged(CommonFileDialogSelectionChangedEventArgs e)
         {
             var handler = SelectionChanged;
             if (handler != null)
@@ -1184,7 +1184,14 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
                 // Don't accept or reject the dialog, keep default settings
                 pResponse = ShellNativeMethods.FileDialogEventOverwriteResponse.Default;
 
-            public void OnSelectionChange(IFileDialog pfd) => parent.OnSelectionChanged(EventArgs.Empty);
+            public void OnSelectionChange(IFileDialog pfd)
+            {
+                pfd.GetFileName(out string text);
+                pfd.GetFolder(out IShellItem folderItem);
+                folderItem.GetDisplayName(ShellNativeMethods.ShellItemDesignNameOptions.FileSystemPath, out IntPtr folderPtr);
+                string folder = Marshal.PtrToStringAuto(folderPtr);
+                parent.OnSelectionChanged(new CommonFileDialogSelectionChangedEventArgs(folder, text));
+            }
 
             public void OnShareViolation(
                 IFileDialog pfd,

--- a/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialogSelectionChangedEventArgs.cs
+++ b/source/WindowsAPICodePack/Shell/CommonFileDialogs/CommonFileDialogSelectionChangedEventArgs.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Microsoft.WindowsAPICodePack.Shell
+{
+    /// <summary>
+    /// Custom event arguments.
+    /// </summary>
+    public class CommonFileDialogSelectionChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommonFileDialogSelectionChangedEventArgs"/> class.
+        /// </summary>
+        public CommonFileDialogSelectionChangedEventArgs(string folder, string fileName)
+        {
+            Folder = folder;
+            FileName = fileName;
+        }
+
+
+
+        /// <summary>
+        /// Gets the name of the selected folder.
+        /// </summary>
+        /// <value>
+        /// The name of the selected folder.
+        /// </value>
+        public string Folder { get; }
+
+
+
+        /// <summary>
+        /// Gets the name of the selected file.
+        /// </summary>
+        /// <value>
+        /// The name of the selected file.
+        /// </value>
+        public string FileName { get; }
+    }
+}


### PR DESCRIPTION
Added custom CommonFileDialogSelectionChangedEventArgs, in order to work with the currently selected folder and file names in the SelectionChanged event handler. If there is some other way to obtain that information inside the event handler, which I missed, please comment.