### PR TITLE
Fixed struct layout changes inadvertently caused by reformatting

### DIFF
--- a/source/WindowsAPICodePack/Core/Interop/TaskDialogs/EnableThemingInScope.cs
+++ b/source/WindowsAPICodePack/Core/Interop/TaskDialogs/EnableThemingInScope.cs
@@ -142,16 +142,17 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             }
         }
 
+        [StructLayout(LayoutKind.Sequential)]
         private struct ACTCTX
         {
             public int cbSize;
             public uint dwFlags;
-            public string lpApplicationName;
+            public string lpSource;
+            public ushort wProcessorArchitecture;
+            public ushort wLangId;
             public string lpAssemblyDirectory;
             public string lpResourceName;
-            public string lpSource;
-            public ushort wLangId;
-            public ushort wProcessorArchitecture;
+            public string lpApplicationName;
         }
     }
 }

--- a/source/WindowsAPICodePack/ExtendedLinguisticServices/MappingResultState.cs
+++ b/source/WindowsAPICodePack/ExtendedLinguisticServices/MappingResultState.cs
@@ -5,10 +5,11 @@ using System;
 namespace Microsoft.WindowsAPICodePack.ExtendedLinguisticServices
 {
     /// <summary>This class serves as the result status of asynchronous calls to ELS and as the result status of linguistic exceptions.</summary>
+    [StructLayout(LayoutKind.Sequential)]
     public struct MappingResultState
     {
-        private readonly string _errorMessage;
         private readonly int _hResult;
+        private readonly string _errorMessage;
 
         internal MappingResultState(int hResult, string errorMessage)
         {

--- a/source/WindowsAPICodePack/Sensors/ObjectModel/SensorManager.cs
+++ b/source/WindowsAPICodePack/Sensors/ObjectModel/SensorManager.cs
@@ -23,10 +23,11 @@ namespace Microsoft.WindowsAPICodePack.Sensors
     }
 
     /// <summary>Data associated with a sensor type GUID.</summary>
+    [StructLayout(LayoutKind.Sequential)]
     internal struct SensorTypeData
     {
-        private readonly SensorDescriptionAttribute sda;
         private readonly Type sensorType;
+        private readonly SensorDescriptionAttribute sda;
 
         public SensorTypeData(Type sensorClassType, SensorDescriptionAttribute sda)
         {

--- a/source/WindowsAPICodePack/Shell/Interop/ShellObjectWatcher/ShellObjectWatcherNativeMethods.cs
+++ b/source/WindowsAPICodePack/Shell/Interop/ShellObjectWatcher/ShellObjectWatcherNativeMethods.cs
@@ -6,13 +6,14 @@ using System.Runtime.InteropServices.ComTypes;
 namespace Microsoft.WindowsAPICodePack.Shell.Interop
 {
     /// <summary>Wraps the native Windows MSG structure.</summary>
+    [StructLayout(LayoutKind.Sequential)]
     public struct Message
     {
-        private readonly IntPtr lparam;
-        private readonly uint msg;
-        private readonly int time;
         private readonly IntPtr windowHandle;
+        private readonly uint msg;
         private readonly IntPtr wparam;
+        private readonly IntPtr lparam;
+        private readonly int time;
         private NativePoint point;
 
         /// <summary>Creates a new instance of the Message struct</summary>
@@ -90,19 +91,22 @@ namespace Microsoft.WindowsAPICodePack.Shell.Interop
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct WindowClassEx
     {
-        internal IntPtr BackgroundBrushHandle;
-        internal string ClassName;
-        internal IntPtr CursorHandle;
-        internal int ExtraClassBytes;
-        internal int ExtraWindowBytes;
-        internal IntPtr IconHandle;
-        internal IntPtr InstanceHandle;
-        internal string MenuName;
         internal uint Size;
-        internal IntPtr SmallIconHandle;
         internal uint Style;
 
         internal ShellObjectWatcherNativeMethods.WndProcDelegate WndProc;
+
+        internal int ExtraClassBytes;
+        internal int ExtraWindowBytes;
+        internal IntPtr InstanceHandle;
+        internal IntPtr IconHandle;
+        internal IntPtr CursorHandle;
+        internal IntPtr BackgroundBrushHandle;
+
+        internal string MenuName;
+        internal string ClassName;
+
+        internal IntPtr SmallIconHandle;
     }
 
     internal static class ShellObjectWatcherNativeMethods


### PR DESCRIPTION
Returned ACTCTX, MappingResultState, SensorTypeData, Message and WindowClassEx layouts to original to address #43.