### PR TITLE
Fixed struct layout changes and readied projects for 1.1.5 release 

### DIFF
--- a/source/WindowsAPICodePack/Core/Core.csproj
+++ b/source/WindowsAPICodePack/Core/Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.WindowsAPICodePack</AssemblyName>
     <PackageId>Microsoft-WindowsAPICodePack-Core</PackageId>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <Title>$(AssemblyName)</Title>
     <Authors>rpastric;contre;dahall</Authors>
     <Company>Microsoft</Company>
@@ -11,14 +11,14 @@
     <PackageLicenseUrl>https://github.com/contre/Windows-API-Code-Pack-1.1/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/contre/Windows-API-Code-Pack-1.1</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The Core code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2019-10-18.</Description>
+    <Description>The Core code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2020-01-04.</Description>
     <PackageReleaseNotes>See CHANGELOG.md in project site. https://github.com/contre/Windows-API-Code-Pack-1.1/blob/master/CHANGELOG.md </PackageReleaseNotes>
     <Copyright>Copyright © 2020</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageTags>WindowsAPICodePack</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.0;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Microsoft.WindowsAPICodePack</RootNamespace>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net2')) Or $(TargetFramework.StartsWith('netcoreapp3')) Or $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net5')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/source/WindowsAPICodePack/Core/Interop/TaskDialogs/EnableThemingInScope.cs
+++ b/source/WindowsAPICodePack/Core/Interop/TaskDialogs/EnableThemingInScope.cs
@@ -142,16 +142,17 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             }
         }
 
+        [StructLayout(LayoutKind.Sequential)]
         private struct ACTCTX
         {
             public int cbSize;
             public uint dwFlags;
-            public string lpApplicationName;
+            public string lpSource;
+            public ushort wProcessorArchitecture;
+            public ushort wLangId;
             public string lpAssemblyDirectory;
             public string lpResourceName;
-            public string lpSource;
-            public ushort wLangId;
-            public ushort wProcessorArchitecture;
+            public string lpApplicationName;
         }
     }
 }

--- a/source/WindowsAPICodePack/ExtendedLinguisticServices/ExtendedLinguisticServices.csproj
+++ b/source/WindowsAPICodePack/ExtendedLinguisticServices/ExtendedLinguisticServices.csproj
@@ -1,63 +1,63 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <AssemblyName>Microsoft.WindowsAPICodePack.ExtendedLinguisticServices</AssemblyName>
-    <PackageId>Microsoft-WindowsAPICodePack-ExtendedLinguisticServices</PackageId>
-    <VersionPrefix>1.1.4</VersionPrefix>
-    <Title>$(AssemblyName)</Title>
-    <Authors>rpastric;contre;dahall</Authors>
-    <Company>Microsoft</Company>
-    <Product>Microsoft Windows API Code Pack for .NET Framework</Product>
-    <PackageLicenseUrl>https://github.com/contre/Windows-API-Code-Pack-1.1/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/contre/Windows-API-Code-Pack-1.1</PackageProjectUrl>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The Extended Linguistic Services code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2019-10-18.</Description>
-    <PackageReleaseNotes>See CHANGELOG.md in project site. https://github.com/contre/Windows-API-Code-Pack-1.1/blob/master/CHANGELOG.md </PackageReleaseNotes>
-    <Copyright>Copyright © 2020</Copyright>
-    <NeutralLanguage>en-US</NeutralLanguage>
-    <PackageTags>WindowsAPICodePack</PackageTags>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <UseWindowsForms>true</UseWindowsForms>
-    <LangVersion>latest</LangVersion>
-    <RootNamespace>Microsoft.WindowsAPICodePack.ExtendedLinguisticServices</RootNamespace>
-    <DocumentationFile>..\bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>ProjectSignKey.snk</AssemblyOriginatorKeyFile>
+	<AssemblyName>Microsoft.WindowsAPICodePack.ExtendedLinguisticServices</AssemblyName>
+	<PackageId>Microsoft-WindowsAPICodePack-ExtendedLinguisticServices</PackageId>
+	<VersionPrefix>1.1.5</VersionPrefix>
+	<Title>$(AssemblyName)</Title>
+	<Authors>rpastric;contre;dahall</Authors>
+	<Company>Microsoft</Company>
+	<Product>Microsoft Windows API Code Pack for .NET Framework</Product>
+	<PackageLicenseUrl>https://github.com/contre/Windows-API-Code-Pack-1.1/LICENSE</PackageLicenseUrl>
+	<PackageProjectUrl>https://github.com/contre/Windows-API-Code-Pack-1.1</PackageProjectUrl>
+	<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+	<Description>The Extended Linguistic Services code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2020-01-04.</Description>
+	<PackageReleaseNotes>See CHANGELOG.md in project site. https://github.com/contre/Windows-API-Code-Pack-1.1/blob/master/CHANGELOG.md </PackageReleaseNotes>
+	<Copyright>Copyright © 2020</Copyright>
+	<NeutralLanguage>en-US</NeutralLanguage>
+	<PackageTags>WindowsAPICodePack</PackageTags>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	  <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+	  <UseWindowsForms>true</UseWindowsForms>
+	<LangVersion>latest</LangVersion>
+	<RootNamespace>Microsoft.WindowsAPICodePack.ExtendedLinguisticServices</RootNamespace>
+	<DocumentationFile>..\bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+	<SignAssembly>true</SignAssembly>
+	<AssemblyOriginatorKeyFile>ProjectSignKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net2')) Or $(TargetFramework.StartsWith('net3')) Or $(TargetFramework.StartsWith('net4')) ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+	<Reference Include="System" />
+	<Reference Include="System.Core" />
+	<Reference Include="System.Xml.Linq" />
+	<Reference Include="System.Data.DataSetExtensions" />
+	<Reference Include="System.Data" />
+	<Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Core\Core.csproj" />
+	<ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="Resources\LocalizedMessages.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>LocalizedMessages.resx</DependentUpon>
-    </Compile>
+	<Compile Update="Resources\LocalizedMessages.Designer.cs">
+	  <DesignTime>True</DesignTime>
+	  <AutoGen>True</AutoGen>
+	  <DependentUpon>LocalizedMessages.resx</DependentUpon>
+	</Compile>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Update="Resources\LocalizedMessages.resx">
-      <CustomToolNamespace>Microsoft.WindowsAPICodePack.Resources</CustomToolNamespace>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>LocalizedMessages.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
+	<EmbeddedResource Update="Resources\LocalizedMessages.resx">
+	  <CustomToolNamespace>Microsoft.WindowsAPICodePack.Resources</CustomToolNamespace>
+	  <Generator>ResXFileCodeGenerator</Generator>
+	  <LastGenOutput>LocalizedMessages.Designer.cs</LastGenOutput>
+	</EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/source/WindowsAPICodePack/ExtendedLinguisticServices/MappingResultState.cs
+++ b/source/WindowsAPICodePack/ExtendedLinguisticServices/MappingResultState.cs
@@ -5,10 +5,11 @@ using System;
 namespace Microsoft.WindowsAPICodePack.ExtendedLinguisticServices
 {
     /// <summary>This class serves as the result status of asynchronous calls to ELS and as the result status of linguistic exceptions.</summary>
+    [StructLayout(LayoutKind.Sequential)]
     public struct MappingResultState
     {
-        private readonly string _errorMessage;
         private readonly int _hResult;
+        private readonly string _errorMessage;
 
         internal MappingResultState(int hResult, string errorMessage)
         {

--- a/source/WindowsAPICodePack/ExtendedLinguisticServices/MappingResultState.cs
+++ b/source/WindowsAPICodePack/ExtendedLinguisticServices/MappingResultState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.WindowsAPICodePack.ExtendedLinguisticServices
 {

--- a/source/WindowsAPICodePack/Sensors/ObjectModel/SensorManager.cs
+++ b/source/WindowsAPICodePack/Sensors/ObjectModel/SensorManager.cs
@@ -4,6 +4,7 @@ using Microsoft.WindowsAPICodePack.Sensors.Resources;
 using MS.WindowsAPICodePack.Internal;
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Microsoft.WindowsAPICodePack.Sensors

--- a/source/WindowsAPICodePack/Sensors/ObjectModel/SensorManager.cs
+++ b/source/WindowsAPICodePack/Sensors/ObjectModel/SensorManager.cs
@@ -23,10 +23,11 @@ namespace Microsoft.WindowsAPICodePack.Sensors
     }
 
     /// <summary>Data associated with a sensor type GUID.</summary>
+    [StructLayout(LayoutKind.Sequential)]
     internal struct SensorTypeData
     {
-        private readonly SensorDescriptionAttribute sda;
         private readonly Type sensorType;
+        private readonly SensorDescriptionAttribute sda;
 
         public SensorTypeData(Type sensorClassType, SensorDescriptionAttribute sda)
         {

--- a/source/WindowsAPICodePack/Sensors/Sensors.csproj
+++ b/source/WindowsAPICodePack/Sensors/Sensors.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.WindowsAPICodePack.Sensors</AssemblyName>
     <PackageId>Microsoft-WindowsAPICodePack-Sensors</PackageId>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <Title>$(AssemblyName)</Title>
     <Authors>rpastric;contre;dahall</Authors>
     <Company>Microsoft</Company>
@@ -11,14 +11,14 @@
     <PackageLicenseUrl>https://github.com/contre/Windows-API-Code-Pack-1.1/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/contre/Windows-API-Code-Pack-1.1</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The Sensors code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2019-10-18.</Description>
+    <Description>The Sensors code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2020-01-04.</Description>
     <PackageReleaseNotes>See CHANGELOG.md in project site. https://github.com/contre/Windows-API-Code-Pack-1.1/blob/master/CHANGELOG.md </PackageReleaseNotes>
     <Copyright>Copyright © 2020</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageTags>WindowsAPICodePack</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Microsoft.WindowsAPICodePack.Sensors</RootNamespace>
@@ -29,7 +29,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net2')) Or $(TargetFramework.StartsWith('net3')) Or $(TargetFramework.StartsWith('net4')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/source/WindowsAPICodePack/Shell/Interop/ShellObjectWatcher/ShellObjectWatcherNativeMethods.cs
+++ b/source/WindowsAPICodePack/Shell/Interop/ShellObjectWatcher/ShellObjectWatcherNativeMethods.cs
@@ -6,13 +6,14 @@ using System.Runtime.InteropServices.ComTypes;
 namespace Microsoft.WindowsAPICodePack.Shell.Interop
 {
     /// <summary>Wraps the native Windows MSG structure.</summary>
+    [StructLayout(LayoutKind.Sequential)]
     public struct Message
     {
-        private readonly IntPtr lparam;
-        private readonly uint msg;
-        private readonly int time;
         private readonly IntPtr windowHandle;
+        private readonly uint msg;
         private readonly IntPtr wparam;
+        private readonly IntPtr lparam;
+        private readonly int time;
         private NativePoint point;
 
         /// <summary>Creates a new instance of the Message struct</summary>
@@ -90,19 +91,22 @@ namespace Microsoft.WindowsAPICodePack.Shell.Interop
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct WindowClassEx
     {
-        internal IntPtr BackgroundBrushHandle;
-        internal string ClassName;
-        internal IntPtr CursorHandle;
-        internal int ExtraClassBytes;
-        internal int ExtraWindowBytes;
-        internal IntPtr IconHandle;
-        internal IntPtr InstanceHandle;
-        internal string MenuName;
         internal uint Size;
-        internal IntPtr SmallIconHandle;
         internal uint Style;
 
         internal ShellObjectWatcherNativeMethods.WndProcDelegate WndProc;
+
+        internal int ExtraClassBytes;
+        internal int ExtraWindowBytes;
+        internal IntPtr InstanceHandle;
+        internal IntPtr IconHandle;
+        internal IntPtr CursorHandle;
+        internal IntPtr BackgroundBrushHandle;
+
+        internal string MenuName;
+        internal string ClassName;
+
+        internal IntPtr SmallIconHandle;
     }
 
     internal static class ShellObjectWatcherNativeMethods

--- a/source/WindowsAPICodePack/Shell/Shell.csproj
+++ b/source/WindowsAPICodePack/Shell/Shell.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.WindowsAPICodePack.Shell</AssemblyName>
     <PackageId>Microsoft-WindowsAPICodePack-Shell</PackageId>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <Title>$(AssemblyName)</Title>
     <Authors>rpastric;contre;dahall</Authors>
     <Company>Microsoft</Company>
@@ -11,14 +11,14 @@
     <PackageLicenseUrl>https://github.com/contre/Windows-API-Code-Pack-1.1/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/contre/Windows-API-Code-Pack-1.1</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The Shell code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of </Description>
+    <Description>The Shell code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2020-01-04.</Description>
     <PackageReleaseNotes>See CHANGELOG.md in project site. https://github.com/contre/Windows-API-Code-Pack-1.1/blob/master/CHANGELOG.md </PackageReleaseNotes>
     <Copyright>Copyright © 2020</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageTags>WindowsAPICodePack</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net2')) Or $(TargetFramework.StartsWith('net3')) Or $(TargetFramework.StartsWith('net4')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="CustomMarshalers" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/WindowsAPICodePack/ShellExtensions/ShellExtensions.csproj
+++ b/source/WindowsAPICodePack/ShellExtensions/ShellExtensions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.WindowsAPICodePack.ShellExtensions</AssemblyName>
     <PackageId>Microsoft-WindowsAPICodePack-ShellExtensions</PackageId>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.5</VersionPrefix>
     <Title>$(AssemblyName)</Title>
     <Authors>rpastric;contre;dahall</Authors>
     <Company>Microsoft</Company>
@@ -11,14 +11,14 @@
     <PackageLicenseUrl>https://github.com/contre/Windows-API-Code-Pack-1.1/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/contre/Windows-API-Code-Pack-1.1</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The ShellExtensions code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2019-10-18.</Description>
+    <Description>The ShellExtensions code for the WindowsAPICodePack. This is an updated version containing all available bug fixes for this code as of 2020-01-04.</Description>
     <PackageReleaseNotes>See CHANGELOG.md in project site. https://github.com/contre/Windows-API-Code-Pack-1.1/blob/master/CHANGELOG.md </PackageReleaseNotes>
     <Copyright>Copyright © 2020</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageTags>WindowsAPICodePack</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;net462;net472;net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net2')) Or $(TargetFramework.StartsWith('net3')) Or $(TargetFramework.StartsWith('net4')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />


### PR DESCRIPTION
* Returned ACTCTX, MappingResultState, SensorTypeData, Message and WindowClassEx layouts to original to address #43.
* Updated project versions to 1.1.5
* Added .NET 5.0, removed .NET Core 3.0 (unsupported), and fixed dependency condition in project files