### PR TITLE
Fix TaskDialog.DefaultButton property is ignored

### DIFF
--- a/source/WindowsAPICodePack/Core/Dialogs/TaskDialogs/TaskDialog.cs
+++ b/source/WindowsAPICodePack/Core/Dialogs/TaskDialogs/TaskDialog.cs
@@ -815,7 +815,11 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
                 }
 
                 // Set default button and add elevation icons to appropriate buttons.
-                settings.NativeConfiguration.defaultButtonIndex = FindDefaultButtonId(sourceList);
+                var defaultBtn = FindDefaultButtonId(sourceList);
+                if (defaultBtn != TaskDialogNativeMethods.NoDefaultButtonSpecified)
+                {
+                    settings.NativeConfiguration.defaultButtonIndex = defaultBtn;
+                }
 
                 ApplyElevatedIcons(settings, sourceList);
             }


### PR DESCRIPTION
The TaskDialog.DefaultButton property is ignored if the dialog contains other buttons/command links, event though they are not set as Default.